### PR TITLE
Fix stack and queue DOM interactions

### DIFF
--- a/js/queue/queue-dom.js
+++ b/js/queue/queue-dom.js
@@ -17,8 +17,12 @@ const clearQueueInput = () => {
 }
 
 const generateListQueue = () => {
-  // ... your code goes here
-  for (i = 1; i <= newStack.MAX_SIZE; i++) {
+  // Create placeholders for the maximum number of items the
+  // queue can handle. The original implementation attempted
+  // to access `newStack.MAX_SIZE`, which doesn't exist in this
+  // context and resulted in a runtime error when rendering the
+  // queue. Use the queue instance's `MAX_SIZE` instead.
+  for (let i = 1; i <= queue.MAX_SIZE; i++) {
     const newLi = document.createElement("li")
     newLi.classList.add("inactive")
     queueUL.appendChild(newLi)
@@ -62,9 +66,11 @@ const removeFromQueue = () => {
   const lastItems = document.querySelectorAll(".list-queue .active")
   if (lastItems.length >= 1) {
     lastItems[0].remove()
-    newLi = document.createElement("li")
+    let newLi = document.createElement("li")
     newLi.className = "inactive"
-    queueUL.insertBefore(newLi, queueUL.childNodes[queueUL.length - 1])
+    // Append the placeholder element at the end of the list to keep
+    // the visual representation aligned with the queue's capacity.
+    queueUL.appendChild(newLi)
 
     queue.dequeue()
 

--- a/js/stack/stack-dom.js
+++ b/js/stack/stack-dom.js
@@ -66,7 +66,12 @@ const removeFromStack = () => {
     lastItems[lastItems.length - 1].classList.remove("active")
     lastItems[lastItems.length - 1].classList.add("inactive")
 
-    newStack.dequeue()
+    // Remove the top element from the data structure
+    // Using "dequeue" here would raise an error since stacks
+    // expose a `pop` method instead. This bug prevented the DOM
+    // from synchronizing with the underlying StackDataStructure
+    // and threw a runtime exception when removing items.
+    newStack.pop()
     clearStackInput()
   } else {
     generateWarningStack("underflow")


### PR DESCRIPTION
## Summary
- Use `pop` when removing items from stack UI to match data structure API
- Initialize queue placeholders using queue's own MAX_SIZE and append new placeholders when dequeuing

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689980edbe38832c8c9c7636b5d4616c